### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,4 +38,4 @@ cp $(tmsh list sys file ssl-cert ca-bundle.crt -hidden |grep cache-path | sed -E
 ## Create the log file
 touch /var/log/acmehandler
 
-return 0
+exit 0


### PR DESCRIPTION
changed 'return 0' to 'exit 0' as return is not valid outside a function call (and errored out) and exit is more appropriate for exiting the script